### PR TITLE
fix: let scripts detect current runtime

### DIFF
--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v bun || command -v node)" "$0" "$@"
 
 /*
   Compile/transpile client-side nue- components to JavaScript

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v bun || command -v node)" "$0" "$@"
 
 console.info(`
 👍 Welcome to Nue!

--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v bun || command -v node)" "$0" "$@"
 
 /*
   Minifies Nue JS files into a single JS file (nue.js)

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v bun || command -v node)" "$0" "$@"
 
 /*
   Generates a sample HTML page using Nue server-side rendering

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v bun || command -v node)" "$0" "$@"
 
 // a super minimal web server to serve files on the current working directory
 import { join, extname } from 'node:path'


### PR DESCRIPTION
Fixes #7 
Removes the need to explicitly use the `--bun` flag on start:
```bash
# Previously
bun run --bun start

# Now
bun run start
```
It is more intuitive, because we use `npm run start`.

Updated the shebang to determine with which runtime to execute the script. The solution is a bit hacky and inspired by [this](https://unix.stackexchange.com/questions/65235/universal-node-js-shebang/65295#65295). Initially, it runs as a shell script to detect and execute further code with either `bun` or `node`. Preventively, updated all shebangs.