### PR TITLE
Feat: Improved DX

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+export { default, create } from './scripts/create.js'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
 
   "scripts": {
-    "start": "nue create",
+    "start": "nue create || (./scripts/cli.js minify --prod && ./scripts/cli.js render && ./scripts/cli.js compile && ./scripts/cli.js server)",
     "minify": "nue minify",
     "render": "nue render",
     "compile": "nue compile",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git"
   },
   "bin": {
-    "create-nue": "./scripts/init.js",
+    "create-nue": "./scripts/bin.js",
     "nue": "./scripts/cli.js"
   },
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
 
   "scripts": {
     "start": "nue create || (./scripts/cli.js minify --prod && ./scripts/cli.js render && ./scripts/cli.js compile && ./scripts/cli.js server)",
-    "minify": "nue minify",
-    "render": "nue render",
-    "compile": "nue compile",
-    "serve": "cd www && nue server"
+    "minify": "nue minify || ./scripts/cli.js minify --prod",
+    "render": "nue render || ./scripts/cli.js render",
+    "compile": "nue compile || ./scripts/cli.js compile",
+    "serve": "cd www && nue server || ./scripts/cli.js server"
   },
   "dependencies": {
     "nuejs-core": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,16 @@
     "type": "git"
   },
   "bin": {
-    "create-nue": "./scripts/init.js"
+    "create-nue": "./scripts/init.js",
+    "nue": "./scripts/cli.js"
   },
 
   "scripts": {
-    "start": "npm run minify && npm run render && npm run compile && npm run serve",
-    "serve": "cd www && ../scripts/server.js",
-    "compile": "./scripts/compile.js",
-    "minify": "./scripts/minify.js",
-    "render": "./scripts/render.js"
+    "start": "nue create",
+    "minify": "nue minify",
+    "render": "nue render",
+    "compile": "nue compile",
+    "serve": "cd www && nue server"
   },
   "dependencies": {
     "nuejs-core": "^0.1.0",

--- a/scripts/bin.js
+++ b/scripts/bin.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import create from '../index.js'
+
+console.info('👍 Welcome to Nue!')
+
+const prompts = {}; // TODO: Implement parsing prompts
+
+create(prompts);

--- a/scripts/bin.js
+++ b/scripts/bin.js
@@ -4,6 +4,6 @@ import create from '../index.js'
 
 console.info('👍 Welcome to Nue!')
 
-const prompts = {}; // TODO: Implement parsing prompts
+const prompts = { prod: false } // TODO: Implement parsing prompts
 
-create(prompts);
+create(prompts)

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/* NOTE:
+  The code here is a placeholder.
+  I just wanted to get it working as simple as possible.
+  The implementation may vary depending on the design. It is a topic to discuss.
+*/
+
+import { DEFAULT_OPTS } from './create.js'
+
+const argv = process.isBun ? Bun.argv : process.argv
+const script = argv[2]
+const opts = { ...DEFAULT_OPTS } // TODO: Implement parsing opts
+
+try {
+  (await import(`./${script}.js`)).default(opts)
+} catch {
+  console.error(`Invalid script name: ${script}`)
+}

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -10,7 +10,7 @@ import { DEFAULT_OPTS } from './create.js'
 
 const argv = process.isBun ? Bun.argv : process.argv
 const script = argv[2]
-const opts = { ...DEFAULT_OPTS } // TODO: Implement parsing opts
+const opts = { ...DEFAULT_OPTS, ...{ prod: argv[3] == '--prod' } } // TODO: Implement parsing opts
 
 try {
   (await import(`./${script}.js`)).default(opts)

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -7,8 +7,10 @@
 */
 import { compileFile } from 'nuejs-core'
 
-const target_js = 'www/islands.js'
-
-// compile nue source code for browser execution
-await compileFile('src/islands.nue', target_js)
-console.info('compiled', target_js)
+export default async function (opts) {
+  const target_js = 'www/islands.js'
+  
+  // compile nue source code for browser execution
+  await compileFile('src/islands.nue', target_js)
+  console.info('compiled', target_js)
+}

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 export const DEFAULT_OPTS = {
+  prod: false,
   port: 8080
 }
 

--- a/scripts/create.js
+++ b/scripts/create.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+export const DEFAULT_OPTS = {
+  port: 8080
+}
+
+export async function create(opts = {}) {
+  opts = { ...DEFAULT_OPTS, ...opts }
+
+  // The order is preserved
+  const scripts = ['minify', 'render', 'compile', 'server']
+
+  const mods = await Promise.allSettled(
+    scripts.map(script => import(`./${script}.js`))
+  );
+
+  for (const { value: mod } of mods) {
+    await mod.default(opts)
+  }
+}
+
+export default create

--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -10,6 +10,14 @@ import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 
 export default async function (opts) {
+  if (!opts.prod) {
+    // TODO: Scaffold template via package binary
+    const info = 'This feature is not yet available, please see https://github.com/nuejs/create-nue#installation'
+    console.warn(info)
+    await fs.writeFile('placeholder.txt', info)
+    process.exit(0)
+  }
+
   try {
     let Bundler = process.isBun ? Bun : await import('esbuild');
 

--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -9,31 +9,37 @@
 import { promises as fs } from 'node:fs'
 import { join } from 'node:path'
 
-try {
-  let Bundler = process.isBun ? Bun : await import('esbuild')
+export default async function (opts) {
+  try {
+    let Bundler = process.isBun ? Bun : await import('esbuild');
 
-  await Bundler.build({
-    entryPoints: [join('node_modules', 'nuejs-core', 'src', 'nue.js')],
-    format: 'esm',
-    bundle: true,
-    outdir: 'www',
-    minify: true
-  })
+    await Bundler.build({
+      entryPoints: [join('node_modules', 'nuejs-core', 'src', 'nue.js')],
+      format: 'esm',
+      bundle: true,
+      outdir: 'www',
+      minify: true,
+    });
 
-  console.log('Minified Nue to wwwl/nue.js with', process.isBun ? 'Bun' : 'ESBuild')
+    console.log(
+      'Minified Nue to wwwl/nue.js with',
+      process.isBun ? 'Bun' : 'ESBuild'
+    );
+  } catch (e) {
+    console.log(
+      'No builder found (esbuild or Bun)',
+      'www/nue.js is not minified'
+    );
+    await copyNue();
+  }
 
-} catch (e) {
-  console.log('No builder found (esbuild or Bun)', 'www/nue.js is not minified')
-  await copyNue()
-}
-
-
-// no bundler -> just copy
-async function copyNue() {
-  const dir = join('node_modules', 'nuejs-core', 'src')
-  const files = await fs.readdir(dir)
-  for (const name of files) {
-    await fs.copyFile(join(dir, name), join('www', name))
+  // no bundler -> just copy
+  async function copyNue() {
+    const dir = join('node_modules', 'nuejs-core', 'src')
+    const files = await fs.readdir(dir)
+    for (const name of files) {
+      await fs.copyFile(join(dir, name), join('www', name))
+    }
   }
 }
 

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -10,29 +10,31 @@ import { parse, render } from 'nuejs-core'
 import { promises as fs } from 'node:fs'
 import yaml from 'js-yaml'
 
-// read() function for reading assets
-const read = async (name, dir='src') => await fs.readFile(dir + '/' + name, 'utf-8')
-
-// read primary CSS
-const primary_css = await read('primary.css', 'www/css')
-
-// read dependencies (server-side components)
-const lib  = parse(await read('components.nue'))
-
-// read website data: title, description, etc.
-const data = yaml.load(await read('content.data'))
-
-// read page layout
-const page = await read('layout.nue')
-
-// set extra, dynamic properties to data
-data.primary_css = primary_css.replace(/\s+/g, ' ')
-data.timestamp = new Date()
-
-// generate HTML with the render() method
-const html = '<!DOCTYPE html>\n\n' + render(page, data, lib)
-
-// write index.html
-await fs.writeFile('./www/index.html', html)
-
-console.log('wrote', 'www/index.html')
+export default async function (opts) {
+  // read() function for reading assets
+  const read = async (name, dir='src') => await fs.readFile(dir + '/' + name, 'utf-8')
+  
+  // read primary CSS
+  const primary_css = await read('primary.css', 'www/css')
+  
+  // read dependencies (server-side components)
+  const lib  = parse(await read('components.nue'))
+  
+  // read website data: title, description, etc.
+  const data = yaml.load(await read('content.data'))
+  
+  // read page layout
+  const page = await read('layout.nue')
+  
+  // set extra, dynamic properties to data
+  data.primary_css = primary_css.replace(/\s+/g, ' ')
+  data.timestamp = new Date()
+  
+  // generate HTML with the render() method
+  const html = '<!DOCTYPE html>\n\n' + render(page, data, lib)
+  
+  // write index.html
+  await fs.writeFile('./www/index.html', html)
+  
+  console.log('wrote', 'www/index.html')
+}

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -5,34 +5,36 @@ import { join, extname } from 'node:path'
 import http from 'node:http'
 import fs from 'node:fs'
 
-const TYPES = {
-  html: 'text/html; charset=UTF-8',
-  js:   'application/javascript',
-  svg:  'image/svg+xml',
-  ico:  'image/x-icon',
-  png:  'image/png',
-  jpg:  'image/jpg',
-  css:  'text/css'
-}
-
-const PORT = 8080
-
-http.createServer(async (req, res) => {
-  let { url } = req
-  if (url.endsWith('/')) url += 'index.html'
-  const path = join('.', url)
-  const ext = extname(path).slice(1)
-  const head = { 'Content-Type': TYPES[ext] }
-
-  try {
-    res.writeHead(200, head)
-    fs.createReadStream(path).pipe(res)
-
-  } catch(e) {
-    res.writeHead(404, head)
-    res.end('')
+export default async function (opts) {
+  const TYPES = {
+    html: 'text/html; charset=UTF-8',
+    js:   'application/javascript',
+    svg:  'image/svg+xml',
+    ico:  'image/x-icon',
+    png:  'image/png',
+    jpg:  'image/jpg',
+    css:  'text/css'
   }
+  
+  const PORT = opts.port
 
-}).listen(PORT)
-
-console.log(process.isBun ? 'Bun' : 'Node', `HTTP server at http://127.0.0.1:${PORT}/`)
+  http.createServer(async (req, res) => {
+    let { url } = req
+    if (url.endsWith('/')) url += 'index.html'
+    const path = join('.', url)
+    const ext = extname(path).slice(1)
+    const head = { 'Content-Type': TYPES[ext] }
+  
+    try {
+      res.writeHead(200, head)
+      fs.createReadStream(path).pipe(res)
+  
+    } catch(e) {
+      res.writeHead(404, head)
+      res.end('')
+    }
+  
+  }).listen(PORT)
+  
+  console.log(process.isBun ? 'Bun' : 'Node', `HTTP server at http://127.0.0.1:${PORT}/`)
+}


### PR DESCRIPTION
> **NOTE**
> Creating a PR to `master`, a branch for development-only would be awesome!

## Features

Improved DX to match scaffolding tools standards.

Templates can now be created via one of the following methods:

- Execute the package `[1]`
```bash
npx create-nue
bunx create-nue
```

- Shorthand for executing the `create-*` packages `[1]`
```bash
npm create nue
bun create nue
yarn create nue
pnpm create nue
```

- Use package entry point binary `[2]` (probably not preferred, but possible)
```bash
nue-create
```

- Use `nue` CLI directly `[2]` (also probably not preferred, but very hand to call internally)
```bash
nue create
```
`nue <script>` runs one of the provided scripts (in `/scripts` as an exported funtion, see the changes below). Can also call `nue render`, etc.

- Imperatively by calling the package function
```js
import create from 'create-nue'
create( /* pass options */ )
```

`[1]` - the package has to be published
`[2]` - the package has to be installed locally

All of the above scaffold a placeholder, instead of a real template, because the original one is not suitable. This is a topic for another PR, which I can do once this PR gets accepted.

> **NOTE**
> It fixes the issue for Windows users, which was caused because Windows can't run a script with the './`. All of the above use package _binaries_. We provide a path and the package manager executes the corresponding file internally. The issue is number 8, but I don't mark it, to not close it - we scaffold only a placeholder with the above.

> **NOTE**
> To test the package by hand without publishing, it can be linked instead (run `npm link` when in project's directory). Linking is for devs-only. If linked, remember to remove from the npm's global cache when done testing by hand (I forgot and lost some time to weird behavior 😅)

I saw that someone has published a fork of this repo, but it has many (unwanted?) changes. Hope this problem will be resolved soon. `create-nue` is a nice and clean name 👍

Also, due to the already published `create-nue` package, there may be a name conflict and linking this PR may not work. In that case change `name` and the key of  `"./scripts/bin.js"` in `package.json` to something else, for example `create-nue-app`

## Changes

To focus only on the CLI part, I did not change the folder structure. I placed all scripts in `/scripts`, except for `index.js`.

- Changed all scripts (`minify.js`, `render.js`, `compile.js`, `server.js`) to exported functions. This is a breaking change. They are called via `create()` or the `nue` CLI.
- Added `create.js` with a function `create()` that calls all of the scripts listed above
- Added `cli.js` which is an entry point for the `nue` CLI. It accepts inline tags: a script name and options. A script name is one of the above, including `create`. Options are not yet parsed (they are a topic to discuss).
- Added `bin.js` which is an entry point binary for the package (called via `npx create-nue`, etc). It parses user prompts and and then scaffolds the template
- Add `index.js` to export the `create()` function
- All npm scripts now either use the `nue` CLI or execute `cli.js` directly. The latter is an equivalent to what was done previously, so there shouldn't be new errors. The main use of `cli.js` is to parse options (which is not yet implemented)

The reason for changing scripts to functions is to implement logic for parsing options in one place (for now it's `cli.js`). We could just have a function for parsing options, but having one file instead is a good pattern for CLI, and maybe a `nue-cli` package in the future.

By the way, nice project! 👍