### PR TITLE
fix: explicitly call node for scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   },
 
   "scripts": {
-    "start": "./scripts/cli.js start",
-    "minify": "./scripts/cli.js minify",
-    "render": "./scripts/cli.js render",
-    "compile": "./scripts/cli.js compile",
-    "serve": "./scripts/cli.js serve"
+    "start": "node ./scripts/cli.js start",
+    "minify": "node ./scripts/cli.js minify",
+    "render": "node ./scripts/cli.js render",
+    "compile": "node ./scripts/cli.js compile",
+    "serve": "node ./scripts/cli.js serve"
   },
 
   "dependencies": {

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 
 const script = process.argv[2]
 


### PR DESCRIPTION
Fix nuejs/nuejs#71
Fix nuejs/nuejs#72

Shebang does not work on Windows.
The fix is to explicitly call node for all scripts.
See https://github.com/nuejs/nuejs/issues/71#issuecomment-1745847892