### PR TITLE
Fix: styling of `glow` code blocks

### DIFF
--- a/simple-blog/posts/syntax.css
+++ b/simple-blog/posts/syntax.css
@@ -4,6 +4,10 @@
   --glow-padding: 1.5em;
 }
 
+[glow] {
+  background-color: var(--glow-bg-color);
+}
+
 /* rounding */
 article > [glow], [tabs] {
   border-radius: .6em;


### PR DESCRIPTION
In `Simple Blog` template added background color to all `glow` code blocks. Based on [the glow introduction](https://nuejs.org/blog/introducing-glow/), I think that was simply missing.

Before:
![before-1](https://github.com/nuejs/create-nue/assets/80765461/d53b9bf0-13eb-4650-9cf3-d641487c4568)
![before-2](https://github.com/nuejs/create-nue/assets/80765461/3eb4e425-8614-4696-b06e-e1e3343b8d44)

After:
![after-1](https://github.com/nuejs/create-nue/assets/80765461/3f4302a6-f627-4f25-a81d-86e534e2b581)
![after-2](https://github.com/nuejs/create-nue/assets/80765461/9473fa46-4cf3-4e3b-91d0-5b2f3f74bc09)
