### PR TITLE
fix: create error in windows

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 
 import { promises as fs } from 'node:fs'
-import { sep, join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import * as p from '@clack/prompts'
 import color from 'picocolors';
@@ -9,7 +10,7 @@ import color from 'picocolors';
 async function copyTemplate(name, to) {
   const s = p.spinner()
   s.start('Copying template')
-  const root = new URL('.', import.meta.url).pathname
+  const root = fileURLToPath(dirname(import.meta.url))
   const src = join(root, name)
   // const filter = path =>  !path.includes(sep + '.')
   await fs.cp(src, to, { recursive: true, force: true })


### PR DESCRIPTION
I've tested the create command both on Windows and Mac separately.
There are no issues.
Can you publish a alpha version? I can test it on my own Windows 10 machine.

- `node ./cli.js`
- `bun ./cli.js`
- `bun link && bun create nue`

fix #35 
fix https://github.com/nuejs/nue/issues/122
